### PR TITLE
Add Rust flags for macOS target configurations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,14 @@
 # Incremental compilation for faster development builds
 incremental = true
 
+# Prevent link errors on macOS
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+
 # ============================================================================
 # Target-Specific Configuration
 # ============================================================================


### PR DESCRIPTION
Added target-specific Rust flags to prevent link errors on macOS.

Fixes: https://github.com/horizonanalytic/astrora/issues/1